### PR TITLE
feat(handlebars): Create "ifCond" helper to allow versatility

### DIFF
--- a/lib/helpers-hbs.js
+++ b/lib/helpers-hbs.js
@@ -1,6 +1,15 @@
 var Handlebars = require('handlebars');
 
-Handlebars.registerHelper('ifCond', function(v1, operator, v2, options) {
+Handlebars.registerHelper('ifCond', function(v1, operator, v2, regExFlag, options) {
+  if (options == null && regExFlag) {
+    options = regExFlag;
+    regExFlag = null;
+  }
+
+  if (regExFlag == null) {
+    regExFlag = 'i';
+  }
+
   switch (operator) {
     // case '==':
     //   return (v1 == v2) ? options.fn(this) : options.inverse(this);
@@ -19,7 +28,7 @@ Handlebars.registerHelper('ifCond', function(v1, operator, v2, options) {
     case '||':
       return (v1 || v2) ? options.fn(this) : options.inverse(this);
     case 'regex':
-      return ((v1 || '').match(v2)) ? options.fn(this) : options.inverse(this);
+      return ((v1 || '').match(new RegExp(v2 || '', regExFlag))) ? options.fn(this) : options.inverse(this);
     default:
       return options.inverse(this);
   }

--- a/lib/helpers-hbs.js
+++ b/lib/helpers-hbs.js
@@ -1,0 +1,26 @@
+var Handlebars = require('handlebars');
+
+Handlebars.registerHelper('ifCond', function(v1, operator, v2, options) {
+  switch (operator) {
+    // case '==':
+    //   return (v1 == v2) ? options.fn(this) : options.inverse(this);
+    case '===':
+      return (v1 === v2) ? options.fn(this) : options.inverse(this);
+    case '<':
+      return (v1 < v2) ? options.fn(this) : options.inverse(this);
+    case '<=':
+      return (v1 <= v2) ? options.fn(this) : options.inverse(this);
+    case '>':
+      return (v1 > v2) ? options.fn(this) : options.inverse(this);
+    case '>=':
+      return (v1 >= v2) ? options.fn(this) : options.inverse(this);
+    case '&&':
+      return (v1 && v2) ? options.fn(this) : options.inverse(this);
+    case '||':
+      return (v1 || v2) ? options.fn(this) : options.inverse(this);
+    case 'regex':
+      return ((v1 || '').match(v2)) ? options.fn(this) : options.inverse(this);
+    default:
+      return options.inverse(this);
+  }
+});

--- a/lib/util.js
+++ b/lib/util.js
@@ -6,6 +6,8 @@ var semver = require('semver');
 var _ = require('lodash');
 var stringify = require('json-stringify-safe');
 
+require('../lib/helpers-hbs');
+
 function compileTemplates(templates) {
   var main = templates.mainTemplate;
   var headerPartial = templates.headerPartial;

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -42,6 +42,130 @@ describe('util', function() {
 
       expect(compiled()).to.equal('partial1\npartial2\npartial3\n');
     });
+    describe('helpers', function() {
+      describe('ifCond', function() {
+        it('should work with "Equal" (===)', function() {
+          var templates = {
+            mainTemplate: '{{> partial1}}{{> partial2}}{{> partial3}}',
+            partials: {
+              partial1: 'partial1\n',
+              partial2: '{{#ifCond "github" "===" "bitbucket"}}partial2\n{{/ifCond}}',
+              partial3: 'partial3\n',
+              partial4: null
+            }
+          };
+
+          var compiled = util.compileTemplates(templates);
+
+          expect(compiled()).to.equal('partial1\npartial3\n');
+        });
+        it('should work with "Lower Than" (<)', function() {
+          var templates = {
+            mainTemplate: '{{> partial1}}{{> partial2}}{{> partial3}}',
+            partials: {
+              partial1: 'partial1\n',
+              partial2: '{{#ifCond "3" "<" "3"}}partial2\n{{/ifCond}}',
+              partial3: 'partial3\n',
+              partial4: null
+            }
+          };
+
+          var compiled = util.compileTemplates(templates);
+
+          expect(compiled()).to.equal('partial1\npartial3\n');
+        });
+        it('should work with Lower Than Equal (<=)', function() {
+          var templates = {
+            mainTemplate: '{{> partial1}}{{> partial2}}{{> partial3}}',
+            partials: {
+              partial1: 'partial1\n',
+              partial2: '{{#ifCond "2" "<=" "2"}}partial2\n{{/ifCond}}',
+              partial3: 'partial3\n',
+              partial4: null
+            }
+          };
+
+          var compiled = util.compileTemplates(templates);
+
+          expect(compiled()).to.equal('partial1\npartial2\npartial3\n');
+        });
+        it('should work with Greater Than (>)', function() {
+          var templates = {
+            mainTemplate: '{{> partial1}}{{> partial2}}{{> partial3}}',
+            partials: {
+              partial1: 'partial1\n',
+              partial2: '{{#ifCond "2" ">" "2"}}partial2\n{{/ifCond}}',
+              partial3: 'partial3\n',
+              partial4: null
+            }
+          };
+
+          var compiled = util.compileTemplates(templates);
+
+          expect(compiled()).to.equal('partial1\npartial3\n');
+        });
+        it('should work with Greater Than Equal (>=)', function() {
+          var templates = {
+            mainTemplate: '{{> partial1}}{{> partial2}}{{> partial3}}',
+            partials: {
+              partial1: 'partial1\n',
+              partial2: '{{#ifCond "4" ">=" "2"}}partial2\n{{/ifCond}}',
+              partial3: 'partial3\n',
+              partial4: null
+            }
+          };
+
+          var compiled = util.compileTemplates(templates);
+
+          expect(compiled()).to.equal('partial1\npartial2\npartial3\n');
+        });
+        it('should work with "AND" (&&)', function() {
+          var templates = {
+            mainTemplate: '{{> partial1}}{{> partial2}}{{> partial3}}',
+            partials: {
+              partial1: 'partial1\n',
+              partial2: '{{#ifCond "truthy" "&&" ""}}partial2\n{{/ifCond}}',
+              partial3: 'partial3\n',
+              partial4: null
+            }
+          };
+
+          var compiled = util.compileTemplates(templates);
+
+          expect(compiled()).to.equal('partial1\npartial3\n');
+        });
+        it('should work with "OR" (||)', function() {
+          var templates = {
+            mainTemplate: '{{> partial1}}{{> partial2}}{{> partial3}}',
+            partials: {
+              partial1: 'partial1\n',
+              partial2: '{{#ifCond "" "||" "truthy"}}partial2\n{{/ifCond}}',
+              partial3: 'partial3\n',
+              partial4: null
+            }
+          };
+
+          var compiled = util.compileTemplates(templates);
+
+          expect(compiled()).to.equal('partial1\npartial2\npartial3\n');
+        });
+        it('should work with "Regular Expression" (.match)', function() {
+          var templates = {
+            mainTemplate: '{{> partial1}}{{> partial2}}{{> partial3}}',
+            partials: {
+              partial1: 'partial1\n',
+              partial2: '{{#ifCond "https://github.com" "regex" "github"}}partial2\n{{/ifCond}}',
+              partial3: 'partial3\n',
+              partial4: null
+            }
+          };
+
+          var compiled = util.compileTemplates(templates);
+
+          expect(compiled()).to.equal('partial1\npartial2\npartial3\n');
+        });
+      });
+    });
   });
 
   describe('functionify', function() {

--- a/test/util.spec.js
+++ b/test/util.spec.js
@@ -164,6 +164,21 @@ describe('util', function() {
 
           expect(compiled()).to.equal('partial1\npartial2\npartial3\n');
         });
+        it('should work with the default fallback', function() {
+          var templates = {
+            mainTemplate: '{{> partial1}}{{> partial2}}{{> partial3}}',
+            partials: {
+              partial1: 'partial1\n',
+              partial2: '{{#ifCond "github" "==" "github"}}partial2\n{{/ifCond}}',
+              partial3: 'partial3\n',
+              partial4: null
+            }
+          };
+
+          var compiled = util.compileTemplates(templates);
+
+          expect(compiled()).to.equal('partial1\npartial3\n');
+        });
       });
     });
   });


### PR DESCRIPTION
Creates a new helper block called "ifCond" that receives 3/4 parameters and performs a corresponding match:

``` handlebars
{{#ifCond @root.items ">=" "5"}}
```

will return:

``` js
context.items >= 5
```

and:

``` handlebars
{{#ifCond @root.host "regex" "github|gitlab" "i"}}
```

will return:

``` js
context.host.match(/github|gitlab/i)
```

It admits up to 4 parameters:
- left side of comparision
- operator
- right side of comparision
- regex flags (only when operator === 'regex')

Currently it handles the following operators:
`===`, `<`, `<=`, `>`, `>=`, `&&`, `||`

The `==` operator it's not included because it makes jslint to fail.
